### PR TITLE
Reset existing styles before applying new ones

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -255,11 +255,20 @@ var game = {
     });
   },
 
+  resetStyles: function() {
+    $('#pond').attr('style', '');
+    $('.frog').each(function() {
+      $(this).attr('style', '');
+    });
+  },
+
   applyStyles: function() {
     var level = levels[game.level];
     var nativeCode = $('#code').val();
     var objectStyles = game.parseNativeCode(nativeCode);
     var map = level.objectToSelectorMap || {};
+    
+    game.resetStyles();
     objectStyles.forEach(function (objectStyle) {
       var selector = map[objectStyle.object] || '';
       var element = $('#pond ' +  selector);


### PR DESCRIPTION
Thank you for adapting the Flexbox Froggy for the ASDK/Texture's Layout API! I enjoyed the gameplay and also learned about AlignItems and JustifyContent :)

**Bug description**
1. Navigate to https://huynguyen.dev/froggy-asdk-layout/ (Level 1 of 13)
2. In the editor, type in `stack.justifyContent = ASStackLayoutJustifyContentEnd;`
3. Observe: the frog has moved to the lilypad
4. Delete line `stack.justifyContent = ASStackLayoutJustifyContentEnd;` from the editor

**Expected**: the frog's position gets reset back to the initial position
**Actual**: the frog stays on the lilipad; next button stays enabled